### PR TITLE
Regimes Clustering with Random Forest algorithm

### DIFF
--- a/backend/backend/algorithms/buy_apple.py
+++ b/backend/backend/algorithms/buy_apple.py
@@ -8,6 +8,7 @@ import pandas as pd
 # Logging
 from websocket import create_connection
 
+# Data frame To JSON
 from ..api.create_response import create_json_response
 
 

--- a/backend/backend/algorithms/buy_apple.py
+++ b/backend/backend/algorithms/buy_apple.py
@@ -1,7 +1,12 @@
+# Zipline API
 from zipline.api import order, symbol
-from websocket import create_connection
 from zipline import run_algorithm
+
+# Data frames
 import pandas as pd
+
+# Logging
+from websocket import create_connection
 
 from ..api.create_response import create_json_response
 

--- a/backend/backend/algorithms/mean_reversion.py
+++ b/backend/backend/algorithms/mean_reversion.py
@@ -1,12 +1,18 @@
-from scipy import stats
-import pandas as pd
+# Zipline API
 from zipline.pipeline import Pipeline
 from zipline.api import attach_pipeline, pipeline_output, schedule_function, order
 from zipline.pipeline.factors import AverageDollarVolume
 from zipline.utils.events import date_rules
 from zipline import run_algorithm
+
+# Data frame
+import pandas as pd
+from scipy import stats
+
+# Logging
 from websocket import create_connection
 
+# Data frame to JSON
 from ..api.create_response import create_json_response
 
 

--- a/backend/backend/algorithms/random_forest_regression.py
+++ b/backend/backend/algorithms/random_forest_regression.py
@@ -1,11 +1,19 @@
-from sklearn.ensemble import RandomForestRegressor
-import numpy as np
-import pandas as pd
-from websocket import create_connection
+# Zipline API
 from zipline.api import schedule_function, order_target_percent, symbol
 from zipline.utils.events import date_rules, time_rules
 from zipline import run_algorithm
 
+# Data frame
+import numpy as np
+import pandas as pd
+
+# Machine Learning
+from sklearn.ensemble import RandomForestRegressor
+
+# Logging
+from websocket import create_connection
+
+# Data frame to JSON
 from ..api.create_response import create_json_response
 
 

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -9,7 +9,7 @@ import pandas as pd
 import statsmodels.api as sm
 
 # Machine Learning
-from sklearn.cluster import KMeans
+from sklearn.cluster import KMeans, MiniBatchKMeans
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.multiclass import OneVsRestClassifier
 
@@ -20,7 +20,7 @@ from collections import deque
 def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
 
     def initialize(context):
-        context.security = symbol("AAPL")
+        context.security = symbol("AMZN")
         context.long_threshold = 0
         context.short_threshold = -0.06
 
@@ -31,7 +31,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
 
         context.n_clusters = 9
         context.ret_windows = [30]
-        context.window_lengths = [15, 30, 60, 90, 120, 150, 180, 210, 240]
+        context.window_lengths = [30, 90, 150, 210, 240]
         context.lookback = 8 * 250
         context.refresh_frequency = 30
 
@@ -73,7 +73,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
                     y = cluster_data['rets']
 
                     kmeans = KMeans(n_clusters=context.n_clusters, n_init=100, max_iter=500, random_state=42,
-                                    precompute_distances=True, n_jobs=-1)
+                                    precompute_distances=True)
                     kmeans.fit(X)
                     clusters[ret_window]['windows'][window_length] = {
                         "kmeans": kmeans,
@@ -334,6 +334,6 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
     return result
 
 
-result = regimes_clustering_run("2016-01-01", "2016-06-01", 1000000, "abc")
-
-print(result.tail())
+if __name__ == '__main__':
+    result = regimes_clustering_run("2016-01-01", "2016-06-01", 1000000, "abc")
+    print(result.tail())

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -1,0 +1,22 @@
+# Zipline API
+from zipline.api import attach_pipeline, pipeline_output
+from zipline.pipeline import Pipeline
+from zipline.pipeline.data import USEquityPricing
+from zipline.pipeline.factors import AverageDollarVolume
+
+# Math
+import numpy as np
+import pandas as pd
+from scipy import optimize
+from scipy import stats
+import statsmodels.api as sm
+
+# Machine Learning
+from sklearn.cluster import KMeans
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.model_selection import train_test_split
+from sklearn.multiclass import OneVsRestClassifier
+from sklearn.metrics import classification_report, confusion_matrix
+
+# Data structures
+from collections import deque

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -35,7 +35,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
         context.lookback = 8 * 250
         context.refresh_frequency = 30
 
-        context.use_classifier = False
+        context.use_classifier = True
 
         if context.use_classifier:
             context.ret_buckets = {
@@ -72,7 +72,8 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
                     X = cluster_data.drop('rets', axis=1)
                     y = cluster_data['rets']
 
-                    kmeans = KMeans(n_clusters=context.n_clusters, n_init=100, max_iter=500, random_state=42)
+                    kmeans = KMeans(n_clusters=context.n_clusters, n_init=100, max_iter=500, random_state=42,
+                                    precompute_distances=True, n_jobs=-1)
                     kmeans.fit(X)
                     clusters[ret_window]['windows'][window_length] = {
                         "kmeans": kmeans,
@@ -335,4 +336,4 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
 
 result = regimes_clustering_run("2016-01-01", "2016-06-01", 1000000, "abc")
 
-print(result.head())
+print(result.tail())

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -11,9 +11,6 @@ from scipy import optimize
 from scipy import stats
 import statsmodels.api as sm
 
-# Date
-import datetime
-
 # Machine Learning
 from sklearn.cluster import KMeans
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
@@ -28,7 +25,7 @@ from collections import deque
 def regimes_clustering_run():
 
     def initialize(context):
-        context.security = symbol("AAPL")
+        context.security_list = []
         context.long_threshold = 0
         context.short_threshold = -0.06
 
@@ -39,7 +36,7 @@ def regimes_clustering_run():
 
         context.n_clusters = 9
         context.ret_windows = [30]
-        context.window_length = [15, 30, 60, 90, 120, 150, 180, 210, 240]
+        context.window_lengths = [15, 30, 60, 90, 120, 150, 180, 210, 240]
         context.lookback = 8 * 250
         context.refresh_frequency = 30
 
@@ -58,15 +55,83 @@ def regimes_clustering_run():
         context.price_projections = {}
         context.bucket_probs = {}
 
-        attach_pipeline(create_high_dollar_volume_pipeline(), 'top_dollar_volume')
+        context.days_traded = 0
+
+        attach_pipeline(create_high_dollar_volume_pipeline(), 'tdv')
 
     def create_high_dollar_volume_pipeline():
         pipe = Pipeline()
 
-        dollar_volume = AverageDollarVolume(window_length=63)  # 63 days = 1 quarter
+        dollar_volume = AverageDollarVolume(window_length=63)
         pipe.add(dollar_volume, 'dollar_volume')
 
-        high_dollar_volume = dollar_volume.percentile_between(95, 100)  # top 5% by dollar volume
+        high_dollar_volume = dollar_volume.percentile_between(99, 100)  # top 1% by dollar volume
         pipe.set_screen(high_dollar_volume)
 
         return pipe
+
+    def before_trading_start(context, data):
+        context.output = pipeline_output('tdv')
+        context.security_list = context.output.index
+
+        context.days_traded += 1
+
+        if context.model == {} or context.model['refresh_date'] <= context.days_traded:
+            context.model['refresh_date'] = context.days_traded + context.refresh_frequency
+            clusters = {}
+
+            for ret_window in context.ret_windows:
+                clusters[ret_window] = {'windows': {}}
+
+                for window_length in context.window_lengths:
+                    cluster_data = get_cluster_data(context, data, window_length, ret_window)
+                    cluster_data.dropna(inplace=True)
+                    X = cluster_data.drop('rets', axis=1)
+                    y = cluster_data['rets']
+
+                    kmeans = KMeans(n_clusters=context.n_clusters, n_init=100, max_iter=500, random_state=42)
+                    kmeans.fit(X)
+                    clusters[ret_window]['windows'][window_length] = {
+                        "kmeans": kmeans,
+                        "regimes": kmeans.predict(X),
+                        "rets": y
+                    }
+
+            panel = get_X(clusters)
+
+            for ret_window, _ in clusters.items():
+                df = panel[ret_window]
+                ret = df['rets']
+
+                X = df.drop('rets', axis=1)
+                X_train = X.values
+
+                if context.use_classifier:
+
+                    global ret_buckets
+
+                    try:
+                        ret_buckets = context.ret_buckets[ret_window]
+                    except KeyError:
+                        ret_buckets = context.ret_buckets['gen']
+
+                    clf = OneVsRestClassifier(RandomForestClassifier(n_estimators=1000, random_state=42))
+
+                    y = len(ret_buckets) * np.ones(len(ret)).astype(int)
+
+                    for i in range(len(ret_buckets) - 1, -1, -1):
+                        I = ret.values < ret_buckets[i]
+
+                        y[I] = i
+
+                    y_train = y
+
+                    clf.fit(X_train, y_train)
+                    clusters[ret_window]['clf'] = clf
+
+                else:
+                    rfr = RandomForestRegressor(n_estimators=1000, random_state=42)
+                    rfr.fit(X_train, ret.values)
+                    clusters[ret_window]['reg'] = rfr
+
+            context.model['clusters'] = clusters

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -17,14 +17,14 @@ from sklearn.multiclass import OneVsRestClassifier
 from collections import deque
 
 
-def regimes_clustering_run(start_date, end_date, capital_base, ticker, use_clf, log_channel):
+def regimes_clustering_run(start_date, end_date, capital_base, ticker, use_clf, no_shorts, log_channel):
 
     def initialize(context):
         context.security = symbol(ticker)
         context.long_threshold = 0
         context.short_threshold = -0.06
 
-        context.no_shorts = False
+        context.no_shorts = no_shorts
 
         if context.no_shorts:
             set_long_only()

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -19,6 +19,9 @@ from collections import deque
 # Logging
 from websocket import create_connection
 
+# Data frame to JSON
+from ..api.create_response import create_json_response
+
 
 def regimes_clustering_run(start_date, end_date, capital_base, ticker, use_clf, no_shorts, log_channel):
 
@@ -228,7 +231,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, ticker, use_clf, 
             projection_date = context.days_traded + ret_window
             context.price_projections[projection_date] = (1 + est) * data.current(context.security, 'price')
 
-            ws.send(msg_placeholder % ("Random Forest produced a projected return of %s and projected price of %s"
+            ws.send(msg_placeholder % ("Random Forest produced a projected return of %s and price change of %s"
                     % (str(est), str(context.price_projections[projection_date]))))
 
         execute_transactions(context)
@@ -384,4 +387,4 @@ def regimes_clustering_run(start_date, end_date, capital_base, ticker, use_clf, 
     result.dropna(inplace=True)
     ws.close()
 
-    return result
+    return create_json_response(result)

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -35,7 +35,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
         context.lookback = 8 * 250
         context.refresh_frequency = 30
 
-        context.use_classifier = True
+        context.use_classifier = False
 
         if context.use_classifier:
             context.ret_buckets = {
@@ -165,9 +165,15 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
                 if len(ret_buckets) == 1:
                     est = ret_buckets[0] + 2 * prediction - 1
                 else:
+
+                    vectorized_ret_buckets = np.array(ret_buckets)
+
                     v = [ret_buckets[0] - 1] \
-                        + list(0.5 * (np.array(ret_buckets)[1:] + np.array(ret_buckets)[:-1])) \
+                        + list(0.5 * (vectorized_ret_buckets[1:] + vectorized_ret_buckets[:-1])) \
                         + [ret_buckets[-1] + 1]
+
+                    v = np.array(v)
+
                     est = v[prediction]
 
             else:
@@ -195,7 +201,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
                     print("bought")
 
                 elif p < context.short_prob_ub:
-                    order_target_percent(context.security, context.long_only - 1)
+                    order_target_percent(context.security, context.no_shorts - 1)
                     context.last_traded_date = context.days_traded
 
                     print("shorted")
@@ -214,7 +220,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
                     print('bought')
 
                 elif estimate < context.short_threshold:
-                    order_target_percent(context.security, context.long_only - 1)
+                    order_target_percent(context.security, context.no_shorts - 1)
                     context.last_traded_date = context.days_traded
 
                     print('shorted')
@@ -327,6 +333,6 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
     return result
 
 
-result = regimes_clustering_run("2016-01-01", "2017-01-01", 1000000, "abc")
+result = regimes_clustering_run("2016-01-01", "2016-06-01", 1000000, "abc")
 
 print(result.head())

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -57,3 +57,16 @@ def regimes_clustering_run():
         context.return_projections = {}
         context.price_projections = {}
         context.bucket_probs = {}
+
+        attach_pipeline(create_high_dollar_volume_pipeline(), 'top_dollar_volume')
+
+    def create_high_dollar_volume_pipeline():
+        pipe = Pipeline()
+
+        dollar_volume = AverageDollarVolume(window_length=63)  # 63 days = 1 quarter
+        pipe.add(dollar_volume, 'dollar_volume')
+
+        high_dollar_volume = dollar_volume.percentile_between(95, 100)  # top 5% by dollar volume
+        pipe.set_screen(high_dollar_volume)
+
+        return pipe

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -1,5 +1,5 @@
 # Zipline API
-from zipline.api import attach_pipeline, pipeline_output
+from zipline.api import attach_pipeline, pipeline_output, symbol, set_long_only
 from zipline.pipeline import Pipeline
 from zipline.pipeline.data import USEquityPricing
 from zipline.pipeline.factors import AverageDollarVolume
@@ -11,6 +11,9 @@ from scipy import optimize
 from scipy import stats
 import statsmodels.api as sm
 
+# Date
+import datetime
+
 # Machine Learning
 from sklearn.cluster import KMeans
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
@@ -20,3 +23,37 @@ from sklearn.metrics import classification_report, confusion_matrix
 
 # Data structures
 from collections import deque
+
+
+def regimes_clustering_run():
+
+    def initialize(context):
+        context.security = symbol("AAPL")
+        context.long_threshold = 0
+        context.short_threshold = -0.06
+
+        context.no_shorts = False
+
+        if context.no_shorts:
+            set_long_only()
+
+        context.n_clusters = 9
+        context.ret_windows = [30]
+        context.window_length = [15, 30, 60, 90, 120, 150, 180, 210, 240]
+        context.lookback = 8 * 250
+        context.refresh_frequency = 30
+
+        context.use_classifier = True
+
+        if context.use_classifier:
+            context.ret_buckets = {
+                "gen": [-0.04, 0, 0.04]
+            }
+
+        context.long_prob_lb = 0.5
+        context.short_prob_ub = 0.3
+
+        context.model = {}
+        context.return_projections = {}
+        context.price_projections = {}
+        context.bucket_probs = {}

--- a/backend/backend/algorithms/regimes_clustering.py
+++ b/backend/backend/algorithms/regimes_clustering.py
@@ -17,10 +17,10 @@ from sklearn.multiclass import OneVsRestClassifier
 from collections import deque
 
 
-def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
+def regimes_clustering_run(start_date, end_date, capital_base, ticker, use_clf, log_channel):
 
     def initialize(context):
-        context.security = symbol("AAPL")
+        context.security = symbol(ticker)
         context.long_threshold = 0
         context.short_threshold = -0.06
 
@@ -35,7 +35,7 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
         context.lookback = 8 * 250
         context.refresh_frequency = 30
 
-        context.use_classifier = False
+        context.use_classifier = use_clf
 
         if context.use_classifier:
             context.ret_buckets = {
@@ -326,8 +326,3 @@ def regimes_clustering_run(start_date, end_date, capital_base, log_channel):
                            bundle="quantopian-quandl")
 
     return result
-
-
-if __name__ == '__main__':
-    result = regimes_clustering_run("2016-01-01", "2016-06-01", 1000000, "abc")
-    print(result.tail())

--- a/backend/backend/algorithms/rsi_divergence.py
+++ b/backend/backend/algorithms/rsi_divergence.py
@@ -1,10 +1,17 @@
-from ..technical_analysis.analysis import RSI
-from ..api.create_response import create_json_response
-import pandas as pd
-import math
+# Zipline API
 from zipline.api import order_target, symbol, order_target_percent
 from zipline import run_algorithm
+
+# Data frame
+import pandas as pd
+import math
+from ..technical_analysis.analysis import RSI
+
+# Logging
 from websocket import create_connection
+
+# Data frame to JSON
+from ..api.create_response import create_json_response
 
 
 def rsi_div_run(start_date, end_date, capital_base, ticker, log_channel):

--- a/backend/backend/algorithms/trend_follow.py
+++ b/backend/backend/algorithms/trend_follow.py
@@ -1,13 +1,19 @@
-import numpy as np
-import pandas as pd
-import statsmodels.api as sm
+# Zipline API
 from zipline.api import attach_pipeline, pipeline_output, schedule_function, get_open_orders, order_target_percent
 from zipline.pipeline import Pipeline
 from zipline.utils.events import date_rules, time_rules
 from zipline.pipeline.factors import AverageDollarVolume
 from zipline import run_algorithm
 
+# Data frame
+import numpy as np
+import pandas as pd
+import statsmodels.api as sm
+
+# Logging
 from websocket import create_connection
+
+# Data frame to JSON
 from ..api.create_response import create_json_response
 
 


### PR DESCRIPTION
- Implemented `regimes_clustering()` algorithm
- This algorithm predicts price movements by combining two machine learning algorithms, K-means and Random Forest Classifier/Regression. First compute volatility, the normalized trend line, and volatility around the trend line for 30, 90, 120... days into the past. Use unsupervised K-means to cluster these time intervals into regimes. For each regime, train a Random Forest Classifier/Regression to produce the future price change. Long or short based on this predicted price.
- In finance, a [regime](https://quant.stackexchange.com/questions/30139/what-is-a-regime-switch) is simply an interval of time for which a certain model works well. Since the situation of the "world" may change, it is also necessary to change regimes in order for models to remain accurate.