### PR TITLE
Fix static modifier breaking graph component & delete old dist files

### DIFF
--- a/frontend/angular-src/src/app/algorithms/buy-apple/buy-apple.component.ts
+++ b/frontend/angular-src/src/app/algorithms/buy-apple/buy-apple.component.ts
@@ -64,7 +64,7 @@ export class BuyAppleComponent implements OnInit {
     this.beginSim = false;
   }
 
-  static getDate(form: FormControl) {
+  getDate(form: FormControl) {
     return form.value.toISOString().substring(0, 10);
   }
 

--- a/frontend/angular-src/src/app/algorithms/mean-reversion/mean-reversion.component.ts
+++ b/frontend/angular-src/src/app/algorithms/mean-reversion/mean-reversion.component.ts
@@ -66,7 +66,7 @@ export class MeanReversionComponent implements OnInit {
     this.beginSim = false;
   }
 
-  static getDate(form: FormControl) {
+  getDate(form: FormControl) {
     return form.value.toISOString().substring(0, 10);
   }
 

--- a/frontend/angular-src/src/app/algorithms/rand-forest-reg/rand-forest-reg.component.ts
+++ b/frontend/angular-src/src/app/algorithms/rand-forest-reg/rand-forest-reg.component.ts
@@ -88,7 +88,7 @@ export class RandForestRegComponent implements OnInit {
     this.beginSim = false;
   }
 
-  static getDate(form: FormControl) {
+  getDate(form: FormControl) {
     return form.value.toISOString().substring(0, 10);
   }
 

--- a/frontend/angular-src/src/app/algorithms/regimes-clustering/regimes-clustering.component.ts
+++ b/frontend/angular-src/src/app/algorithms/regimes-clustering/regimes-clustering.component.ts
@@ -92,7 +92,7 @@ export class RegimesClusteringComponent implements OnInit {
     this.beginSim = false;
   }
 
-  static getDate(form: FormControl) {
+  getDate(form: FormControl) {
     return form.value.toISOString().substring(0, 10);
   }
 

--- a/frontend/angular-src/src/app/algorithms/rsi-divergence/rsi-divergence.component.ts
+++ b/frontend/angular-src/src/app/algorithms/rsi-divergence/rsi-divergence.component.ts
@@ -87,7 +87,7 @@ export class RsiDivergenceComponent implements OnInit {
   }
 
 
-  static getDate(form: FormControl) {
+  getDate(form: FormControl) {
     return form.value.toISOString().substring(0, 10);
   }
 }

--- a/frontend/angular-src/src/app/algorithms/trend-follow/trend-follow.component.ts
+++ b/frontend/angular-src/src/app/algorithms/trend-follow/trend-follow.component.ts
@@ -62,7 +62,7 @@ export class TrendFollowComponent implements OnInit {
     this.beginSim = false;
   }
 
-  static getDate(form: FormControl) {
+  getDate(form: FormControl) {
     return form.value.toISOString().substring(0, 10);
   }
 }

--- a/frontend/deploy-angular.sh
+++ b/frontend/deploy-angular.sh
@@ -2,8 +2,10 @@
 # This script is to automate the building of the angular frontend
 
 cd angular-src
+echo "Deleting previous static files"
+rm -r dist/ ../../backend/dist/
 echo "Building angular source in prod mode"
-ng build --prod
+ng build
 cd ../
 echo "Copying contents of dist into static files"
 cp -R angular-src/dist/. ../backend/dist/

--- a/frontend/deploy-angular.sh
+++ b/frontend/deploy-angular.sh
@@ -5,7 +5,7 @@ cd angular-src
 echo "Deleting previous static files"
 rm -r dist/ ../../backend/dist/
 echo "Building angular source in prod mode"
-ng build
+ng build --prod
 cd ../
 echo "Copying contents of dist into static files"
 cp -R angular-src/dist/. ../backend/dist/


### PR DESCRIPTION
- static modifier on getDate causes graph component to fail to display because static methods cannot be accessed from template
- modified deployment script to delete old dist files to reduce slug size