### PR TITLE
Added support for loops, iteration, and range

### DIFF
--- a/backend/backend/algorithms/custom_algos/allowed_imports.py
+++ b/backend/backend/algorithms/custom_algos/allowed_imports.py
@@ -29,8 +29,11 @@ GLOBAL_FIELDS = {
     '__builtins__': {
         'str': str,
         'len': len,
+        'int': int,
+        'range': range,
     },
     '__metaclass__': type,
+    '_getiter_': lambda x: x,
     '_write_': lambda x: x,
     '_getattr_': getattr,
     '_setattr_': setattr,


### PR DESCRIPTION
Needed to make statements like

```python
x = [i for i in range(1,3)]
```

to compile and run successfully