### PR TITLE
Fix compile errors not being handled correctly in build algo

### DIFF
--- a/backend/backend/algorithms/custom_algos/template_algorithm.py
+++ b/backend/backend/algorithms/custom_algos/template_algorithm.py
@@ -30,7 +30,9 @@ def template_algorithm(src_code, capital_base, start_date, end_date, log_channel
     if len(byte_code.errors) != 0:
         log('COMPILE ERROR =====')
         for error in byte_code.errors:
-            log(error)
+            formatted_error = error.replace('"', "'")
+            log(formatted_error)
+        logger.close()
         return {
             'done': True,
             'success': False,

--- a/frontend/angular-src/src/app/graph/graph.component.html
+++ b/frontend/angular-src/src/app/graph/graph.component.html
@@ -31,7 +31,7 @@
     </canvas>
   </div>
 
-  <ng-container *ngIf="!done">
+  <ng-container *ngIf="!done && !failed">
     <div class="spinner">
       <mat-spinner></mat-spinner>
     </div>

--- a/frontend/angular-src/src/app/graph/graph.component.ts
+++ b/frontend/angular-src/src/app/graph/graph.component.ts
@@ -44,6 +44,7 @@ export class GraphComponent implements OnInit, OnDestroy {
   private code: string;
 
   public done: boolean;
+  public failed: boolean;
   public finalAlpha: number;
 
   private xaxis: string[];
@@ -63,6 +64,7 @@ export class GraphComponent implements OnInit, OnDestroy {
                private editor: EditorService,
                private scroll: ScrollToService) {
     this.done = false;
+    this.failed = false;
     this.logChannel = null;
     this.xaxis = [];
     this.dataset1 = [];
@@ -213,8 +215,7 @@ export class GraphComponent implements OnInit, OnDestroy {
     else if (this.type === 'custom') {
 
       this.log = this.log.concat('Sending code for compilation, fingers crossed it works!', '\n',
-                                  `Trying to execute between ${this.start} to ${this.end}`, '\n',
-                                  'If it takes a long time it probably failed (no failure msg yet) :(', '\n');
+                                  `Executing backtest between ${this.start} to ${this.end}`, '\n');
 
       this.extractDataFromAPI(
         this.editor.executeSrcCode(this.code, this.capitalBase, this.start, this.end, this.logChannel)
@@ -246,6 +247,9 @@ export class GraphComponent implements OnInit, OnDestroy {
       if (!response) {
         return;
       } else if (!response.done) {
+        return;
+      } else if (response.hasOwnProperty('success') && !response.success) {
+        this.failed = true;
         return;
       } else {
 

--- a/frontend/angular-src/src/app/graph/graph.component.ts
+++ b/frontend/angular-src/src/app/graph/graph.component.ts
@@ -250,6 +250,9 @@ export class GraphComponent implements OnInit, OnDestroy {
         return;
       } else if (response.hasOwnProperty('success') && !response.success) {
         this.failed = true;
+        if (this.ws) {
+          this.ws.close();
+        }
         return;
       } else {
 


### PR DESCRIPTION
Previously,
- FE does not do error checking for if user code execution failed, and always keeps the spinner on.
- Error msgs that contain characters like " don't get sent to the web socket server at all. This is pretty common in compile errors

Now,
- FE will handle by closing websocket and stopping spinner, so user has visual indication that code execution has failed
- Error msgs are now formatted so there are no more issues with character escaping and such.
