### PR TITLE
fix "ws was closed before connection was established" race condition

### DIFF
--- a/frontend/angular-src/src/app/graph/graph.component.ts
+++ b/frontend/angular-src/src/app/graph/graph.component.ts
@@ -224,8 +224,12 @@ export class GraphComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    if (this.subscription !== undefined && this.subscription !== null) {
+    if (this.subscription) {
       this.subscription.unsubscribe();
+    }
+
+    if (this.ws) {
+      this.ws.close();
     }
   }
 
@@ -250,9 +254,6 @@ export class GraphComponent implements OnInit, OnDestroy {
         return;
       } else if (response.hasOwnProperty('success') && !response.success) {
         this.failed = true;
-        if (this.ws) {
-          this.ws.close();
-        }
         return;
       } else {
 


### PR DESCRIPTION
- If compile error is detected immediately and code executor endpoint responds before a ws connection can be established, then no compile messages will be received by the client because client would have already closed the websocket.
- Therefore, the fix is to delay the closing of the websocket until the current client is destroyed - ie user exits the page or requests to execute another code snippet.